### PR TITLE
Add light/dark theme switching

### DIFF
--- a/src-tauri/content/_prefs.json
+++ b/src-tauri/content/_prefs.json
@@ -12,6 +12,7 @@
     "main": "New Computer Modern",
     "mono": "New Computer Modern Mono"
   },
+  "theme": "dark",
   "render_debounce_ms": 400,
   "focused_preview_enabled": true,
   "preserve_scroll_position": true

--- a/src-tauri/src/preferences.rs
+++ b/src-tauri/src/preferences.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use tauri::AppHandle;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(default)]
 pub struct Preferences {
     pub papersize: String,  // Changed from paper_size to papersize for Typst compatibility
     pub margin: Margins,    // Changed from margins to margin for Typst compatibility

--- a/src-tauri/src/preferences.rs
+++ b/src-tauri/src/preferences.rs
@@ -15,6 +15,7 @@ pub struct Preferences {
     pub default_image_width: String,
     pub default_image_alignment: String,
     pub fonts: Fonts,
+    pub theme: String,
     // Preview optimization settings
     pub render_debounce_ms: u32,
     pub focused_preview_enabled: bool,
@@ -49,6 +50,7 @@ impl Default for Preferences {
                 main: "New Computer Modern".to_string(),
                 mono: "Liberation Mono".to_string(),
             },
+            theme: "dark".to_string(),
             // Preview optimization defaults
             render_debounce_ms: 400,  // 400ms for responsive feel
             focused_preview_enabled: true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,14 +19,15 @@ import StatusBar from './components/StatusBar';
 
 function App() {
   const [loading, setLoading] = useState(true);
-  const { 
-    setPreferences, 
-    previewVisible, 
+  const {
+    setPreferences,
+    previewVisible,
     prefsModalOpen,
     editor,
     setCurrentFile,
     setContent,
-    addOpenFile
+    addOpenFile,
+    preferences
   } = useAppStore();
 
   // Initialize app
@@ -112,6 +113,10 @@ Happy writing!
     
     init();
   }, [editor.currentFile, setPreferences, setCurrentFile, setContent, addOpenFile]);
+
+  useEffect(() => {
+    document.body.classList.toggle('light', preferences.theme === 'light');
+  }, [preferences.theme]);
 
   if (loading) {
     return <div className="loading">Loading...</div>;

--- a/src/components/PrefsModal.tsx
+++ b/src/components/PrefsModal.tsx
@@ -200,6 +200,22 @@ const PrefsModal: React.FC = () => {
               </label>
             </div>
           </div>
+
+          <div className="prefs-section">
+            <h3>Theme</h3>
+            <div className="form-group">
+              <label htmlFor="theme">Interface Theme</label>
+              <select
+                id="theme"
+                name="theme"
+                value={formData.theme}
+                onChange={handleInputChange}
+              >
+                <option value="dark">Dark</option>
+                <option value="light">Light</option>
+              </select>
+            </div>
+          </div>
           
           <div className="prefs-section">
             <h3>Images</h3>

--- a/src/components/Toolbar.css
+++ b/src/components/Toolbar.css
@@ -22,7 +22,8 @@
   gap: 0.5rem;
 }
 
-.toolbar-actions button {
+.toolbar-actions button,
+.toolbar-actions select {
   --btn-bg: #059669;       /* emerald-600 - more visible green */
   --btn-bg-hover: #047857; /* emerald-700 - darker hover */
   --btn-bg-active: #065f46;/* emerald-800 - active/pressed */
@@ -47,7 +48,8 @@
   outline: none;
 }
 
-.toolbar-actions button:hover:not(:disabled) {
+.toolbar-actions button:hover:not(:disabled),
+.toolbar-actions select:hover:not(:disabled) {
   background: var(--btn-bg-hover);
   box-shadow: 0 3px 6px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.15) inset;
   transform: translateY(-1px);
@@ -65,11 +67,13 @@
   box-shadow: 0 2px 5px rgba(0,0,0,0.55) inset, 0 0 0 1px rgba(255,255,255,0.06);
 }
 
-.toolbar-actions button:focus-visible {
+.toolbar-actions button:focus-visible,
+.toolbar-actions select:focus-visible {
   box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #2563eb, 0 1px 2px rgba(0,0,0,0.4);
 }
 
-.toolbar-actions button:disabled {
+.toolbar-actions button:disabled,
+.toolbar-actions select:disabled {
   opacity: 0.55;
   cursor: not-allowed;
   background: #475569;
@@ -81,13 +85,16 @@
 /* High-contrast mode support */
 @media (forced-colors: active) {
   .toolbar-actions button,
-  .toolbar-actions button:focus-visible {
+  .toolbar-actions button:focus-visible,
+  .toolbar-actions select,
+  .toolbar-actions select:focus-visible {
     forced-color-adjust: none;
     background: ButtonFace;
     color: ButtonText;
     border-color: ButtonText;
   }
-  .toolbar-actions button:focus-visible { outline: 2px solid Highlight; }
+  .toolbar-actions button:focus-visible,
+  .toolbar-actions select:focus-visible { outline: 2px solid Highlight; }
 }
 
 /* Light theme override if body has light class */
@@ -97,11 +104,13 @@ body.light .toolbar {
   border-bottom-color: #cbd5e1;
 }
 body.light .toolbar-logo h1 { color:#102a43; }
-body.light .toolbar-actions button {
+body.light .toolbar-actions button,
+body.light .toolbar-actions select {
   --btn-bg:#2563eb;
   --btn-bg-hover:#1d4ed8;
   --btn-bg-active:#1e40af;
   --btn-border:#1e3a8a;
   --btn-text:#ffffff;
 }
-body.light .toolbar-actions button:disabled { background:#94a3b8; border-color:#64748b; color:#f1f5f9; }
+body.light .toolbar-actions button:disabled,
+body.light .toolbar-actions select:disabled { background:#94a3b8; border-color:#64748b; color:#f1f5f9; }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { useAppStore } from '../store';
-import { showOpenDialog } from '../api';
+import { showOpenDialog, setPreferences as savePreferences, applyPreferences } from '../api';
 import './Toolbar.css';
 
 const Toolbar: React.FC = () => {
-  const { 
-    previewVisible, 
-    setPreviewVisible, 
+  const {
+    previewVisible,
+    setPreviewVisible,
     setPrefsModalOpen,
-    editor
+    editor,
+    preferences,
+    setPreferences: updatePreferences,
   } = useAppStore();
 
   const handleTogglePreview = () => {
@@ -17,6 +19,16 @@ const Toolbar: React.FC = () => {
 
   const handleOpenPreferences = () => {
     setPrefsModalOpen(true);
+  };
+
+  const handleThemeChange = async (
+    e: React.ChangeEvent<HTMLSelectElement>
+  ) => {
+    const newTheme = e.target.value as 'dark' | 'light';
+    const newPrefs = { ...preferences, theme: newTheme };
+    await savePreferences(newPrefs);
+    updatePreferences(newPrefs);
+    await applyPreferences();
   };
 
   const handleExportPDF = async () => {
@@ -63,10 +75,16 @@ const Toolbar: React.FC = () => {
           📄 Export PDF
         </button>
         
-        <button 
-          onClick={handleOpenPreferences}
-          title="Preferences"
+        <select
+          value={preferences.theme}
+          onChange={handleThemeChange}
+          title="Interface Theme"
         >
+          <option value="dark">Dark</option>
+          <option value="light">Light</option>
+        </select>
+
+        <button onClick={handleOpenPreferences} title="Preferences">
           ⚙️ Preferences
         </button>
       </div>

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,6 +16,7 @@ const defaultPreferences: Preferences = {
     main: 'New Computer Modern',
     mono: 'Liberation Mono',
   },
+  theme: 'dark',
   // Preview optimization settings
   render_debounce_ms: 400,
   focused_preview_enabled: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface Preferences {
   default_image_width: string;
   default_image_alignment: string;
   fonts: Fonts;
+  theme: 'dark' | 'light';
   // Preview optimization settings
   render_debounce_ms: number;
   focused_preview_enabled: boolean;


### PR DESCRIPTION
## Summary
- add `theme` field to preferences and default state
- allow selecting interface theme in preferences modal
- toggle document body class based on chosen theme

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68a1e924638c8333b269c7079c58911e