### PR TITLE
feat: add Windows file-association support

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri = { version = "2.7.0", features = ["protocol-asset"] }
 tauri-plugin-log = "2.3.2"
 tauri-plugin-dialog = "2.3.2"
 tauri-plugin-shell = "2"
+tauri-plugin-single-instance = "2.4.1"
 uuid = { version = "1.3", features = ["v4", "serde"] }
 regex = "1.8"
 tokio = { version = "1.28", features = ["full"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,21 +7,49 @@ mod render_pipeline;
 mod renderer;
 mod utils;
 
+use tauri::{Emitter, Manager};
+
+/// Returns the first `.md` or `.qmd` file path passed as a CLI argument, if any.
+/// Called by the frontend during initialization to detect Windows file-association launches.
+#[tauri::command]
+fn get_launch_file_path() -> Option<String> {
+    std::env::args().skip(1).find(|arg| {
+        let lower = arg.to_lowercase();
+        !arg.starts_with('-') && (lower.ends_with(".md") || lower.ends_with(".qmd"))
+    })
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
+    // When a second instance is launched with a file path (e.g. double-clicking
+    // a .md file while Tideflow is already open), forward it to the running
+    // instance via the `open-file` event and bring the window to focus.
+    .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+        if let Some(path) = args.iter().skip(1).find(|a| {
+            let lower = a.to_lowercase();
+            !a.starts_with('-') && (lower.ends_with(".md") || lower.ends_with(".qmd"))
+        }) {
+            let _ = app.emit("open-file", path);
+        }
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+    }))
     .plugin(tauri_plugin_dialog::init())
     .plugin(tauri_plugin_log::Builder::default().build())
     .plugin(tauri_plugin_shell::init())
-    
+
     .setup(|app| {
         // Initialize app directories if needed
         let app_handle = app.handle();
         utils::initialize_app_directories(app_handle)?;
-        
+
         Ok(())
     })
     .invoke_handler(tauri::generate_handler![
+        get_launch_file_path,
         commands::read_markdown_file,
         commands::read_binary_file,
         commands::write_markdown_file,

--- a/src/hooks/useAppInitialization.ts
+++ b/src/hooks/useAppInitialization.ts
@@ -4,6 +4,7 @@
  */
 
 import { useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { useEditorStore } from '../stores/editorStore';
 import { useUIStore } from '../stores/uiStore';
@@ -52,6 +53,22 @@ export function useAppInitialization() {
         preferencesStore.setPreferences(prefs);
         preferencesStore.setThemeSelection(prefs.theme_id ?? 'default');
         initLogger.debug('preferences loaded', prefs);
+
+        // Check if a file was passed via Windows file-association (double-click or "Open with")
+        const launchFilePath = await invoke<string | null>('get_launch_file_path').catch(() => null);
+        if (launchFilePath) {
+          initLogger.info('opening launch file', launchFilePath);
+          try {
+            const content = await readMarkdownFile(launchFilePath);
+            editorStore.addOpenFile(launchFilePath);
+            editorStore.setCurrentFile(launchFilePath);
+            editorStore.setContent(content);
+            uiStore.setInitialSampleInjected(true);
+            sampleInjected = true;
+          } catch (e) {
+            initLogger.error('Failed to open launch file', e);
+          }
+        }
 
         // Check if this is first time running (no previous session with files)
         const isFirstTime = !session || !session.openFiles || session.openFiles.length === 0;
@@ -215,6 +232,25 @@ export function useAppInitialization() {
           initLogger.warn('TypstQuery: no positions found, falling back to PDF-text extraction');
         });
         register(unlistenTypstFailed);
+
+        // Handle files forwarded from a second instance (single-instance plugin)
+        // Fires when the user double-clicks a .md file while Tideflow is already open.
+        const unlistenOpenFile = await listen<string>('open-file', async (evt) => {
+          const path = evt.payload;
+          if (!path) return;
+          initLogger.info('open-file event received', path);
+          try {
+            const content = await readMarkdownFile(path);
+            const store = useEditorStore.getState();
+            store.addOpenFile(path);
+            store.setCurrentFile(path);
+            store.setContent(content);
+          } catch (e) {
+            initLogger.error('Failed to open forwarded file', e);
+            useUIStore.getState().addToast({ type: 'error', message: `Could not open file: ${path}` });
+          }
+        });
+        register(unlistenOpenFile);
 
         initLogger.info('init complete');
       } catch (error) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
 
   // Optimize build for production
   build: {
-    target: ["es2021", "chrome100", "safari14"],
+    target: ["es2022", "chrome120"],
     minify: !process.env.TAURI_DEBUG ? "esbuild" : false,
     sourcemap: !!process.env.TAURI_DEBUG,
     rollupOptions: {


### PR DESCRIPTION
Problem: Double-clicking a .md file on Windows (or using "Open with → Tideflow") passes the file path as %1 via the Shell, but Tideflow had no CLI argument parsing and no single-instance forwarding, so the file was silently ignored.

Solution:

- Added tauri-plugin-single-instance so when a .md file is opened while Tideflow is already running, the path is forwarded to the existing instance via an open-file event
- Added a get_launch_file_path Tauri command that reads std::env::args() on fresh launch — called by the frontend during init to detect file-association launches
- Handled both paths in useAppInitialization.ts: invoke('get_launch_file_path') for fresh starts, listen('open-file') for forwarded files
- Fixed a pre-existing Vite build failure caused by safari14 in the esbuild target — incompatible with pdfjs-dist 4.x worker bundle (irrelevant for a Tauri desktop app)

Tested on: Windows 11, .md and .qmd file associations

Notes: the vite.config.ts target change fixes a pre-existing bug, so it's worth including with an explanation in the PR description so the maintainer understands it's not part of the core feature